### PR TITLE
Enhace gdax test case, and align decimal scale with Gdax API results

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,31 @@ for authentication APIs and logics and `gdaxutils.py` to store all auxiliary uti
 and modules, etc. We store all python related code under `python` directory, just in case, we add other programming language
 such as Java, or C later in the same repository.
 
-The `tests` directory provides the test case and examples on how to use the APIs from `gdaxfun/gdaxauth.py` and `gdaxfun/gdaxutils.py`.
+The `tests` directory provides the test case and examples on how to use the APIs from 
 
+* `gdaxfun/gdaxauth.py`
+* `gdaxfun/gdaxutils.py`
+* `gdaxfun/gdaxdb.py`
+
+In the `tests` directory, the file with prefix `t_gdaxYYYY` where `YYYY` presents the module name 
+(e.g. `gdaxauth`, `gdaxutils`, `gdaxdb`, etc) are the test files that include examples how to use the APIs respectively.
+`t_gdaxfun.py` is NOT a test file, it is simply an example that invokes some `gdaxutils` APIs to interact with the
+GDAX server. This provides straight forward examples if you want to try out Python Interactive Shell.
+
+```
+.
+├── btcusd_trades.txt
+├── t_gdaxauth.py
+├── t_gdaxauth.pyc
+├── t_gdaxdb.py
+├── t_gdaxfun.py
+└── t_gdaxutils.py
+```
+
+To run the unit test, simply use `python t_gdaxYYYY`. e.g.
+
+```
+python t_gdaxauth.py
+python t_gdaxutils.py
+python t_gdaxdb.py
+```

--- a/python/gdaxfun/gdaxfun/__init__.py
+++ b/python/gdaxfun/gdaxfun/__init__.py
@@ -1,2 +1,4 @@
 from gdaxfun.gdaxauth import GdaxExAuth
 from gdaxfun.gdaxutils import GdaxUtils
+from gdaxfun.gdaxproducts import GdaxProducts
+from gdaxfun.gdaxdb import GdaxDB, GdaxDBLabel, TradeHistory

--- a/python/gdaxfun/gdaxfun/gdaxdb.py
+++ b/python/gdaxfun/gdaxfun/gdaxdb.py
@@ -44,8 +44,23 @@ class GdaxDB():
         db.generate_mapping(create_tables=True)
 
     @db_session
-    def insert_record(self, dict):
-        a = TradeHistory(**dict)
+    def insert_record(self, dparams):
+        t = TradeHistory(**dparams)
+        commit()
+
+    @db_session
+    def query_record(self, tid):
+        t = TradeHistory.get(trade_id=tid)
+        return t.to_dict()
+
+    @db_session
+    def delete_record(self, tid):
+        t = TradeHistory.get(trade_id=tid)
+        t.delete()
+
+    @db_session
+    def count_records(self):
+        return count(t for t in TradeHistory)
 
 #=========================================================================
 # Table to store trade records
@@ -63,7 +78,7 @@ class TradeHistory(db.Entity):
     _table_ = "TradeHistory"
     trade_id = PrimaryKey(int)
     time = Required(int)
-    price = Required(Decimal, precision=38, scale=12)
-    size = Required(Decimal, precision=38, scale=12)
+    price = Required(Decimal, precision=38, scale=8)
+    size = Required(Decimal, precision=38, scale=8)
     side = Required(str)
     productid = Required(str, max_len=7)

--- a/python/gdaxfun/gdaxfun/gdaxutils.py
+++ b/python/gdaxfun/gdaxfun/gdaxutils.py
@@ -1,4 +1,4 @@
-import json
+import simplejson as json
 import requests
 
 #=========================================================================

--- a/python/tests/t_gdaxdb.py
+++ b/python/tests/t_gdaxdb.py
@@ -1,19 +1,28 @@
 import unittest
 import imp
 import os
-import json
 import time
 import datetime
+import simplejson as json
 
 
 class TestGdaxDBSQLite(unittest.TestCase):
 
-    db_config = {'sqlite': {'file_path': os.getcwd() + "/sqlite_test.db"},
-                 'mysql': {},
-                 'postgres': {}
+    test_records = [
+        '{"trade_id": 30499319, "size": "0.00010000", "side": "sell", "price": "15586.37000000", "time": "2017-12-26T06:36:53.21Z"}',
+        '{"trade_id": 30499255, "size": "0.10000000", "side": "buy", "price": "15561.93000000", "time": "2017-12-26T06:35:59.661Z"}'
+    ]
+    # This follows the order from above records. This represent the epoch time
+    # after the 'time' field is converted.
+    test_expected_results = [1514270213, 1514270159]
+
+    db_config = {'sqlite': {'file_path': os.path.join(os.getcwd(), 'sqlite_test.db')},
+                 'mysql': {},  # put mysql configurations here
+                 'postgres': {}  # put postgrresql configuration here
                  }
 
     def setUp(self):
+        self.curr_dir = os.getcwd()
         self.gdaxdb_lib = imp.load_source(
             'gdaxdb', '../gdaxfun/gdaxfun/gdaxdb.py')
         # Initialize authentication parameters and objects
@@ -22,27 +31,61 @@ class TestGdaxDBSQLite(unittest.TestCase):
         self.sqlite_config = self.db_config['sqlite']
         self.gdaxdb.initdb()
 
+    def tearDown(self):
+        if os.path.isfile(self.sqlite_config['file_path']):
+            os.remove(self.sqlite_config['file_path'])
+
     def test_initdb(self):
         self.assertTrue(os.path.isfile(
-            self.sqlite_config['file_path']), "Database file " + self.sqlite_config['file_path'] + " isn't created")
+            self.sqlite_config['file_path']), 'Database file ' + self.sqlite_config['file_path'] + ' isn\'t created')
 
-    def test_insertrecords(self):
-        rec0 = '{"trade_id": 30499319, "size": "0.00010000", "side": "sell", "price": "15586.37000000", "time": "2017-12-26T06:36:53.21Z"}'
-        rec1 = '{"trade_id": 30499255, "size": "0.10000000", "side": "buy", "price": "15561.93000000", "time": "2017-12-26T06:35:59.661Z"}'
-        dict0 = json.loads(rec0)
-        dict1 = json.loads(rec1)
-        dict0['productid'] = 'BTC-USD'
-        dict1['productid'] = 'BTC-USD'
-        t0 = time.strptime(dict0['time'], "%Y-%m-%dT%H:%M:%S.%fZ")
-        # 1514270213
-        dict0['time'] = int((datetime.datetime(t0[0], t0[1], t0[2], t0[3], t0[4], t0[5]) -
+    def test_insert2records(self):
+        for r in self.test_records:
+            d = json.loads(r)
+            d['productid'] = 'BTC-USD'
+            # Convert string time format to integer epoch format
+            t = time.strptime(d['time'], '%Y-%m-%dT%H:%M:%S.%fZ')
+            d['time'] = int((datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5]) -
                              datetime.datetime(1970, 1, 1, 0, 0, 0)).total_seconds())
-        # 1514270159
-        t1 = time.strptime(dict1['time'], "%Y-%m-%dT%H:%M:%S.%fZ")
-        dict1['time'] = int((datetime.datetime(t1[0], t1[1], t1[2], t1[3], t1[4], t1[5]) -
+            self.assertIn(d['time'], self.test_expected_results,
+                          'Epoch time conversion is incorrect, check the APIs you are using')
+            self.gdaxdb.insert_record(d)
+            tid_dict = self.gdaxdb.query_record(d['trade_id'])
+            self.assertEqual(d['trade_id'], tid_dict['trade_id'])
+            self.assertEqual(d['productid'], tid_dict['productid'])
+            self.assertEqual(d['side'], tid_dict['side'])
+            self.assertEqual(d['time'], tid_dict['time'])
+            self.assertEqual(d['price'], str(tid_dict['price']))
+            self.assertEqual(d['size'], str(tid_dict['size']))
+            self.gdaxdb.delete_record(d['trade_id'])
+
+    def test_insertfromfile(self):
+        testf = open(os.path.join(self.curr_dir, 'btcusd_trades.txt'), 'r')
+        rec = testf.readline()
+        rec_cnt = 0
+        while rec != "":
+            # convert input json formatter string to Dictionary
+            d = json.loads(rec)
+            d['productid'] = 'BTC-USD'
+            # Convert string time format to integer epoch format
+            t = time.strptime(d['time'], '%Y-%m-%dT%H:%M:%S.%fZ')
+            d['time'] = int((datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5]) -
                              datetime.datetime(1970, 1, 1, 0, 0, 0)).total_seconds())
-        self.gdaxdb.insert_record(dict0)
-        self.gdaxdb.insert_record(dict1)
+            print json.dumps(d)
+            self.gdaxdb.insert_record(d)
+            tid_dict = self.gdaxdb.query_record(d['trade_id'])
+            self.assertEqual(d['trade_id'], tid_dict['trade_id'])
+            self.assertEqual(d['productid'], tid_dict['productid'])
+            self.assertEqual(d['side'], tid_dict['side'])
+            self.assertEqual(d['time'], tid_dict['time'])
+            self.assertEqual(d['price'], str(tid_dict['price']))
+            self.assertEqual(d['size'], str(tid_dict['size']))
+            rec = testf.readline()
+            rec_cnt += 1
+        testf.close()
+        fetched_cnt = self.gdaxdb.count_records()
+        self.assertEqual(rec_cnt, fetched_cnt, 'Inserted record counts ' + str(rec_cnt) +
+                         ' from test file is not the same from the test database ' + str(fetched_cnt))
 
 
 if __name__ == '__main__':

--- a/python/tests/t_gdaxfun.py
+++ b/python/tests/t_gdaxfun.py
@@ -1,6 +1,6 @@
 import imp
 import os
-import json
+import simplejson as json
 
 # Reformat JSON Content to a more readable fashion
 prettyp = True
@@ -36,8 +36,7 @@ prettyprint(myutils.getCoinTicker('BTC-USD'))
 # it is not necessary.
 trade_http_resp = myutils.getTrades('BTC-USD')
 for tentry in trade_http_resp.json():
-    dict = json.loads(json.dumps(tentry))
-    print(dict)
+    print(json.dumps(tentry))
 
 
 prettyprint(myutils.getOrderBooksLv1('BTC-USD'))


### PR DESCRIPTION
Replace standard json with simplejson.
Add bulk loading test from a sample file from Gdax Trade APIs.
Add more DB abstrated APIs in GdaxDB wrapper class.
Align Decimal precision and scale with the result from GDAX APIs.
Update README.