### PR TITLE
Fix BCH Listing and enable logging

### DIFF
--- a/python/gdaxfun/CHANGES.txt
+++ b/python/gdaxfun/CHANGES.txt
@@ -1,1 +1,3 @@
+v0.1.1, 20180602 -- Migrate from Python2 to Python3 syntax, etc.
+
 v0.1.0, 20171213 -- Initial release.

--- a/python/gdaxfun/README.md
+++ b/python/gdaxfun/README.md
@@ -61,7 +61,7 @@ python setup.py test
 or in this same directory
 
 ```
-nosetests
+nosetests -vv --logging-level=DEBUG
 ```
 
 If you run into the following errors, that means you didn't initialize the envrionment variables

--- a/python/gdaxfun/gdaxfun/gdaxauth.py
+++ b/python/gdaxfun/gdaxfun/gdaxauth.py
@@ -13,8 +13,8 @@ class GdaxExAuth(AuthBase):
         timestamp = str(time.time())
         message = timestamp + request.method + request.path_url + (request.body or '')
         hmac_key = base64.b64decode(self.secret_key)
-        signature = hmac.new(hmac_key, message, hashlib.sha256)
-        signature_b64 = signature.digest().encode('base64').rstrip('\n')
+        signature = hmac.new(hmac_key, message.encode('ascii'), hashlib.sha256)
+        signature_b64 = base64.b64encode(signature.digest())
 
         request.headers.update({
           'CB-ACCESS-SIGN': signature_b64,

--- a/python/gdaxfun/gdaxfun/gdaxdb.py
+++ b/python/gdaxfun/gdaxfun/gdaxdb.py
@@ -1,7 +1,7 @@
 from pony.orm import *
 from decimal import Decimal
 from datetime import time
-from gdaxtables import define_tables
+from gdaxfun.gdaxtables import define_tables
 #=========================================================================
 # This class manage the functions to store json results into a database.
 # Default will be sqlite, but you can point it to a different database if

--- a/python/gdaxfun/gdaxfun/gdaxproducts.py
+++ b/python/gdaxfun/gdaxfun/gdaxproducts.py
@@ -1,39 +1,45 @@
 class GdaxProducts:
     BCH_USD = 1
-    BTC_EUR = 2
-    BTC_GBP = 3
-    BTC_USD = 4
-    ETH_BTC = 5
-    ETH_EUR = 6
-    ETH_USD = 7
-    LTC_BTC = 8
-    LTC_EUR = 9
-    LTC_USD = 10
+    BCH_BTC = 2
+    BCH_EUR = 3
+    BTC_EUR = 4
+    BTC_GBP = 5
+    BTC_USD = 6
+    ETH_BTC = 7
+    ETH_EUR = 8
+    ETH_USD = 9
+    LTC_BTC = 10
+    LTC_EUR = 11
+    LTC_USD = 12
 
     _product_mapping = {
         'BCH-USD': 1,
-        'BTC-EUR': 2,
-        'BTC-GBP': 3,
-        'BTC-USD': 4,
-        'ETH-BTC': 5,
-        'ETH-EUR': 6,
-        'ETH-USD': 7,
-        'LTC-BTC': 8,
-        'LTC-EUR': 9,
-        'LTC-USD': 10
+        'BCH-BTC': 2,
+        'BCH-EUR': 3,
+        'BTC-EUR': 4,
+        'BTC-GBP': 5,
+        'BTC-USD': 6,
+        'ETH-BTC': 7,
+        'ETH-EUR': 8,
+        'ETH-USD': 9,
+        'LTC-BTC': 10,
+        'LTC-EUR': 11,
+        'LTC-USD': 12
     }
 
     _product_integer_to_info = {
         1: 'BCH-USD',
-        2: 'BTC-EUR',
-        3: 'BTC-GBP',
-        4: 'BTC-USD',
-        5: 'ETH-BTC',
-        6: 'ETH-EUR',
-        7: 'ETH-USD',
-        8: 'LTC-BTC',
-        9: 'LTC-EUR',
-        10: 'LTC-USD'
+        2: 'BCH-BTC',
+        3: 'BCH-EUR',
+        4: 'BTC-EUR',
+        5: 'BTC-GBP',
+        6: 'BTC-USD',
+        7: 'ETH-BTC',
+        8: 'ETH-EUR',
+        9: 'ETH-USD',
+        10: 'LTC-BTC',
+        11: 'LTC-EUR',
+        12: 'LTC-USD'
     }
 
     def lookUpInteger(self, gdaxproducts_str):

--- a/python/gdaxfun/gdaxfun/tests/test_gdaxdb.py
+++ b/python/gdaxfun/gdaxfun/tests/test_gdaxdb.py
@@ -70,7 +70,7 @@ class TestGdaxDBSQLite(unittest.TestCase):
             t = time.strptime(d['time'], '%Y-%m-%dT%H:%M:%S.%fZ')
             d['time'] = int((datetime.datetime(t[0], t[1], t[2], t[3], t[4], t[5]) -
                              datetime.datetime(1970, 1, 1, 0, 0, 0)).total_seconds())
-            print json.dumps(d)
+            print(json.dumps(d))
             self.gdaxdb.insert_trade_record(d)
             tid_dict = self.gdaxdb.query_trade_record(d['trade_id'])
             self.assertEqual(d['trade_id'], tid_dict['trade_id'])

--- a/python/gdaxfun/gdaxfun/tests/test_gdaxfun.py
+++ b/python/gdaxfun/gdaxfun/tests/test_gdaxfun.py
@@ -4,9 +4,12 @@ import time
 import datetime
 import simplejson as json
 import gdaxfun
-# import logging
+import logging
 # import sys
 
+logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+            level=logging.DEBUG)
+LOGGER = logging.getLogger(__name__)
 
 class TestGdaxExAuthAndUtils(unittest.TestCase):
     def setUp(self):
@@ -50,23 +53,26 @@ class TestGdaxExAuthAndUtils(unittest.TestCase):
             fetched_resp.ok, "Failed fetching Gdax Products, seeing return code " + str(fetched_resp.status_code))
         for item in fetched_resp.json():
             d = json.loads(json.dumps(item))
+            LOGGER.info('Received coin list {}'.format(json.dumps(item)))
             self.assertEqual(predefined_gdaxprod.lookUpString(
                 predefined_gdaxprod.lookUpInteger(d['id'])), d['id'], "Failed to map " + d['id'] + " in GdaxProducts class, please fix it")
             self.product_list.append(d['id'])
 
     def test_gdaxgetticker(self):
-        # log = logging.getLogger("TestGdaxExAuth.test_gdaxgetticker")
         for c in self.product_list:
+            LOGGER.info('Fetching ticker for coin {}'.format(c))
             self.assertEqual(self.utils.getCoinTicker(
                 c).status_code, 200, "Failed to lookup coin " + c)
 
     def test_gdaxgetorderbooklv1(self):
         for c in self.product_list:
+            LOGGER.info('Fetching orderbook for coin {}'.format(c))
             self.assertEqual(self.utils.getOrderBooksLv1(
                 c).status_code, 200, "Failed to lookup coin order book " + c)
 
     def test_gdaxgetorderbooklv2(self):
         for c in self.product_list:
+            LOGGER.info('Fetching orderbook via WebSocket for coin {}'.format(c))
             self.assertEqual(self.utils.getOrderBooksLv2(
                 c).status_code, 200, "Failed to lookup coin order book " + c)
 


### PR DESCRIPTION
1. Fix BCH listing after CB added it
2. Migrate from Python2 to Python3 syntax. Fixed HMAC API which requires `bytes` as input and encoding is enforced.